### PR TITLE
Add team-only chat window

### DIFF
--- a/config.md
+++ b/config.md
@@ -850,6 +850,17 @@ Format ma zostac taki jak ponizej: `"typ_komunikatu" : true`
   "emotes" : true
 }
 ```
+
+---
+
+## `scripts.ui.separate_team_talk_window`
+
+Ustawienie czy ma byc osobne okno rozmow druzyny
+
+Wartości:
+* `false` - wylaczone
+* `true` - bedzie to osobne okno
+
 ---
 
 ## `scripts.ui.states_window_height`

--- a/config_schema.json
+++ b/config_schema.json
@@ -1342,6 +1342,14 @@
       ]
     },
     {
+      "name": "scripts.ui.separate_team_talk_window",
+      "default_value": false,
+      "field_type": "boolean",
+      "macros_on_modify": [
+        "_ux"
+      ]
+    },
+    {
       "name": "scripts.ui.fancy.enabled",
       "default_value": false,
       "field_type": "boolean",

--- a/scriptsList.lua
+++ b/scriptsList.lua
@@ -274,6 +274,7 @@ return {
     "skrypty/ui/footer_main_modes/main_footer_updater_mode5",
     "skrypty/ui/footer_main_modes/main_footer_updater_mode6",
     "skrypty/ui/talk_window/ui_talk_window",
+    "skrypty/ui/talk_window/ui_team_talk_window",
     "skrypty/ui/talk_window/talk_history",
     "skrypty/ui/gmcp_handlers/gmcp_state_handler",
     "skrypty/ui/gmcp_handlers/gmcp_room_time_handler",

--- a/skrypty/ingress.lua
+++ b/skrypty/ingress.lua
@@ -85,6 +85,26 @@ function scripts.ingress:post_process_message(msg)
         end
         decho("talk_window", timestamp .. scripts.ui.separate_talk_window_prefix .. ansi2decho(gmcp.gmcp_msgs.decoded))
     end
+    if scripts.ui.separate_team_talk_window and scripts.ui.separate_talk_window_msg_types[gmcp.gmcp_msgs.type] then
+        local plain = ansi2string(gmcp.gmcp_msgs.decoded)
+        local team = false
+        if ateam and ateam.team_names then
+            for name, _ in pairs(ateam.team_names) do
+                local pattern = "^" .. string.lower(string.gsub(name, "([^%w])", "%%%1"))
+                if string.lower(plain):find(pattern) then
+                    team = true
+                    break
+                end
+            end
+        end
+        if team then
+            local timestamp = ""
+            if scripts.ui.separate_talk_window_timestamp and string.trim(scripts.ui.separate_talk_window_timestamp) ~= "" then
+                timestamp = string.format("[%s] ", os.date(scripts.ui.separate_talk_window_timestamp))
+            end
+            decho("team_talk_window", timestamp .. scripts.ui.separate_talk_window_prefix .. ansi2decho(gmcp.gmcp_msgs.decoded))
+        end
+    end
     if gmcp.gmcp_msgs.type == "comm" then
         scripts.ui.talk_history:add(msg)
     end

--- a/skrypty/team.lua
+++ b/skrypty/team.lua
@@ -52,13 +52,17 @@ ateam["footer_info_attack_mode_to_text"] = { "A", "AW", "AWR" }
 
 function trigger_func_skrypty_team_start_ateam()
     tempTimer(4, function() ateam:start_ateam() end)
-    tempTimer(5, function() scripts.ui:setup_talk_window() end)
+    tempTimer(5, function()
+        scripts.ui:setup_talk_window()
+        scripts.ui:setup_team_talk_window()
+    end)
 end
 
 
 ateam.loginHandler = scripts.event_register:register_singleton_event_handler(ateam.loginHandler, "loginSuccessful", function()
     ateam:restart_ateam();
     scripts.ui:setup_talk_window()
+    scripts.ui:setup_team_talk_window()
 end)
 
 function trigger_func_skrypty_team_left_team(leaver)

--- a/skrypty/ui.lua
+++ b/skrypty/ui.lua
@@ -6,7 +6,6 @@ scripts.ui.states_windows_loaded = {}
 -- width for wrapping the states window
 scripts.ui.states_window_p_width = 95
 
--- width for wrapping the talk window
 scripts.ui.separate_talk_window_p_width = 0.8
 
 -- prefix for the talk window
@@ -65,6 +64,8 @@ scripts.ui.footer_b = 47
 
 scripts.ui.separate_talk_window = false
 scripts.ui.separate_talk_window_font_size = 12
+
+scripts.ui.separate_team_talk_window = false
 
 scripts.ui.cfg["footer_mode"] = "mode2"
 scripts.ui.cfg["footer_items"] = {

--- a/skrypty/ui/talk_window/ui_team_talk_window.lua
+++ b/skrypty/ui/talk_window/ui_team_talk_window.lua
@@ -1,0 +1,6 @@
+function scripts.ui:setup_team_talk_window()
+    if scripts.ui.separate_team_talk_window then
+        local window = scripts.ui.window:new("team_talk_window", "Rozmowy druzyny", function() return not scripts.ui.separate_talk_window_no_wrap end)
+        window:set_font_size(scripts.ui.separate_talk_window_font_size)
+    end
+end

--- a/skrypty/ui/ui.lua
+++ b/skrypty/ui/ui.lua
@@ -22,6 +22,7 @@ function scripts.ui:setup()
 
     scripts.ui:setup_states_window()
     scripts.ui:setup_talk_window()
+    scripts.ui:setup_team_talk_window()
     
     scripts.ui:setup_footer()
     scripts.ui:setup_footer_closed()


### PR DESCRIPTION
## Summary
- implement a new `team_talk_window` and setup routines
- update team startup to create the team window
- print team messages to `team_talk_window`
- extend configuration and docs for the new window
- list new module in `scriptsList.lua`

## Testing
- `python ./.github/workflows/check_config.py`
- `python ./.github/workflows/check_events.py`
- `python ./.github/workflows/check_require.py`


------
https://chatgpt.com/codex/tasks/task_e_68625b29f778832aabdeebff610b3952