### PR TITLE
Consolidate footer RGB settings into single hex color

### DIFF
--- a/config.md
+++ b/config.md
@@ -1063,9 +1063,7 @@ Wielkosc czcionki w oknie stanow
 
 ---
 
-## `scripts.ui.footer_r`
-## `scripts.ui.footer_g`
-## `scripts.ui.footer_b`
+## `scripts.ui.footer_color`
 
 Kolor stopki
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -1528,25 +1528,10 @@
       ]
     },
     {
-      "name": "scripts.ui.footer_r",
-      "default_value": 0,
-      "field_type": "number",
-      "macros_on_modify": [
-        "_ux"
-      ]
-    },
-    {
-      "name": "scripts.ui.footer_g",
-      "default_value": 0,
-      "field_type": "number",
-      "macros_on_modify": [
-        "_ux"
-      ]
-    },
-    {
-      "name": "scripts.ui.footer_b",
-      "default_value": 47,
-      "field_type": "number",
+      "name": "scripts.ui.footer_color",
+      "default_value": "#00002f",
+      "field_type": "string",
+      "content_type": "hex_color",
       "macros_on_modify": [
         "_ux"
       ]

--- a/skrypty/config/fixers.lua
+++ b/skrypty/config/fixers.lua
@@ -25,3 +25,31 @@ function scripts.config_fixers.fix_beep(config)
     end
     return false
 end
+
+function scripts.config_fixers.fix_footer_color(config)
+    local r = config._config["scripts.ui.footer_r"]
+    local g = config._config["scripts.ui.footer_g"]
+    local b = config._config["scripts.ui.footer_b"]
+    local color = config._config["scripts.ui.footer_color"]
+    local changed = false
+
+    if not color and r and g and b then
+        config._config["scripts.ui.footer_color"] = string.format("#%02X%02X%02X", r, g, b)
+        changed = true
+    end
+
+    if config._config["scripts.ui.footer_r"] then
+        config._config["scripts.ui.footer_r"] = nil
+        changed = true
+    end
+    if config._config["scripts.ui.footer_g"] then
+        config._config["scripts.ui.footer_g"] = nil
+        changed = true
+    end
+    if config._config["scripts.ui.footer_b"] then
+        config._config["scripts.ui.footer_b"] = nil
+        changed = true
+    end
+
+    return changed
+end

--- a/skrypty/ui.lua
+++ b/skrypty/ui.lua
@@ -56,11 +56,7 @@ scripts.ui.footer_map_font_size = 10
 scripts.ui.footer_font_size = 11
 scripts.ui.states_font_size = 11
 
-scripts.ui.footer_r = 0
-scripts.ui.footer_g = 0
-scripts.ui.footer_b = 47
-
-scripts.ui.footer_b = 47
+scripts.ui.footer_color = "#00002f"
 
 scripts.ui.separate_talk_window = false
 scripts.ui.separate_talk_window_font_size = 12

--- a/skrypty/ui/ui_footer.lua
+++ b/skrypty/ui/ui_footer.lua
@@ -35,7 +35,8 @@ function scripts.ui:setup_footer()
     })
 
     scripts.ui.bottom:setStyleSheet(scripts.ui.current_theme:get_footer_stylesheet())
-    scripts.ui.bottom:setColor(scripts.ui.footer_r, scripts.ui.footer_g, scripts.ui.footer_b)
+    local r, g, b = scripts.ui.footer_color:match("#?(%x%x)(%x%x)(%x%x)")
+    scripts.ui.bottom:setColor(tonumber(r, 16), tonumber(g, 16), tonumber(b, 16))
 
     scripts.ui.footer_vertical = Geyser.VBox:new({
         name = "scripts.ui.footer_vertical",


### PR DESCRIPTION
## Summary
- collapse `scripts.ui.footer_r/g/b` into one `scripts.ui.footer_color` hex config
- migrate existing configs from RGB triplet to new hex field
- document and wire up new footer color setting
- mark `scripts.ui.footer_color` schema entry as `hex_color`

## Testing
- `luacheck -q skrypty/ui.lua skrypty/ui/ui_footer.lua skrypty/config/fixers.lua | tail -n 2` *(fails: command not found)*
- `python -m json.tool config_schema.json | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_e_68948430c210832abe3c953935ca36b0